### PR TITLE
Bump GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload your site output
-        uses: withastro/action@v3
+        uses: withastro/action@v6
         with:
           path: ./docs
-          node-version: 20
+          node-version: 24
           package-manager: pnpm
 
   deploy:
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
     if: ${{ github.repository_owner == 'delucis' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm i


### PR DESCRIPTION
In the GitHub workflow [action logs](https://github.com/delucis/starlight-markdown-blocks/actions/runs/23615431264) of this repo, warnings are printed out:

```
build:
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected:
actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

This PR fixes that issue by bumping GitHub workflow actions to their latest versions.